### PR TITLE
Disable cache in GHA for container build

### DIFF
--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -57,5 +57,3 @@ jobs:
           context: .
           file: ./container/Containerfile
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
There can be cases where the build configuration changes, but source code doesn't and in this case it might happen that the build doesn't yield expected result if cache is in use.