### PR TITLE
ci: explicitly define VERSION variable in container build workflow

### DIFF
--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -26,6 +26,38 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Debug Git Info
+        run: |
+          echo "GitHub Ref: ${{ github.ref }}"
+          echo "GitHub Ref Name: ${{ github.ref_name }}"
+          echo "GitHub Ref Type: ${{ github.ref_type }}"
+          echo "Current commit: $(git rev-parse HEAD)"
+          echo "Tags pointing at current commit:"
+          git tag --points-at HEAD
+          echo "git describe output:"
+          git describe --tags || echo "git describe failed"
+
+      - name: Set version
+        id: set_version
+        run: |
+          # Try to get the tag pointing to the current commit
+          TAG=$(git tag --points-at HEAD)
+          if [[ -n "$TAG" ]]; then
+            echo "version=$TAG" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Debug version
+        run: |
+          echo "Using version: ${{ steps.set_version.outputs.version }}"
 
       - name: Docker meta
         id: meta
@@ -48,9 +80,10 @@ jobs:
         uses: docker/build-push-action@v6
         id: build-image
         with:
-          build-args: |-
+          build-args: |
             TARGETOS=linux
             TARGETARCH=amd64
+            VERSION=${{ steps.set_version.outputs.version }}
           push: ${{ github.event_name != 'pull_request' }} # Don't push on PR
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -6,14 +6,16 @@
 # considerably smaller because it doesn't need to have Golang installed.
 ARG BUILDER_IMAGE=docker.io/golang:1.24.0-alpine3.21
 ARG RUNTIME_IMAGE=docker.io/alpine:3.21
-ARG TARGETOS
-ARG TARGETARCH
 
 # Stage 1: Build the zkcloudd binary inside a builder image that will be discarded later.
 # Ignore hadolint rule because hadolint can't parse the variable.
 # See https://github.com/hadolint/hadolint/issues/339
 # hadolint ignore=DL3006
 FROM --platform=$BUILDPLATFORM ${BUILDER_IMAGE} AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+
 ENV GO111MODULE=on
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
@@ -27,8 +29,9 @@ RUN apk update && apk add --no-cache \
 COPY . /app
 WORKDIR /app
 RUN uname -a &&\
+    echo "Building with VERSION=${VERSION}" &&\
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make build && \
+    make build VERSION="${VERSION}" && \
     ./zkcloudd version && \
     file ./zkcloudd && \
     ldd ./zkcloudd


### PR DESCRIPTION
VERSION is now explicitly defined during container build, so that `zkcloudd version` command can display the appropriate git tag / commit.


Added debug infos on the workflow for better verbosity


on an image built upon push on main branch :

```
84be56ae247a:~$ zkcloudd version
main-1b7627c
```

on an image built upon tag creation :
```
ae9b3670bba0:~$ zkcloudd version
v0.1.1
```