### PR TITLE
Revert "Disable cache in GHA for container build"

### DIFF
--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -90,3 +90,5 @@ jobs:
           context: .
           file: ./container/Containerfile
           platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Reverts thezkcloud/zkcloud#13

This was originally done to make CI build include correct tag version in binary, but the problem wasn't in the caching. The version issue was solved by explicitly defining the version. Therefore let's re-enable the caching to improve CI efficiency.